### PR TITLE
GitHub Actions で npm パッケージと Angular ビルドキャッシュを保持する

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,5 +1,5 @@
 name: Deploy to Firebase Hosting on merge
-'on':
+"on":
   push:
     branches:
       - master
@@ -8,10 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles("**/package-lock.json") }}
+
+      - name: Cache build assets
+        uses: actions/cache@v2
+        with:
+          path: .angular
+        key: ${{ runner.os }}-ng
+
       - run: npm ci && npm run build:prod
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUKAGAWA_COFFEE }}'
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUKAGAWA_COFFEE }}"
           channelId: live
           projectId: fukagawa-coffee

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -1,14 +1,28 @@
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+"on": pull_request
 jobs:
   build_and_preview:
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles("**/package-lock.json") }}
+
+      - name: Cache build assets
+        uses: actions/cache@v2
+        with:
+          path: .angular
+        key: ${{ runner.os }}-ng
+
       - run: npm ci && npm run build
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUKAGAWA_COFFEE }}'
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUKAGAWA_COFFEE }}"
           projectId: fukagawa-coffee


### PR DESCRIPTION
## 理由

現状 Actions でのビルド前に行っている `npm ci && npm run build` でキャッシュが効いていないため時間がかかってしまっている。

## 完了要件

以下の2箇所をキャッシュする。

- ~/.npm
- .angular/