### PR TITLE
Eメールログインを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/router": "~13.3.4",
         "@angular/service-worker": "~13.3.4",
         "firebase": "^9.6",
+        "ngx-webstorage": "^9.0.0",
         "rxjs": "~7.5.5",
         "tslib": "^2.4.0",
         "zone.js": "^0.11.5"
@@ -26313,6 +26314,18 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/ngx-webstorage": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-webstorage/-/ngx-webstorage-9.0.0.tgz",
+      "integrity": "sha512-OighIRoNiGlJLM+mcb850ZkmEdY4JYnGNqKy91hlMgmD9zvUCwC+6pcv1NMncxBP9vnQAqRb65cdY5MBppGM/Q==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^13.0.0",
+        "@angular/core": "^13.0.0"
+      }
+    },
     "node_modules/nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -51835,6 +51848,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "ngx-webstorage": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-webstorage/-/ngx-webstorage-9.0.0.tgz",
+      "integrity": "sha512-OighIRoNiGlJLM+mcb850ZkmEdY4JYnGNqKy91hlMgmD9zvUCwC+6pcv1NMncxBP9vnQAqRb65cdY5MBppGM/Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "nice-napi": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@angular/router": "~13.3.4",
     "@angular/service-worker": "~13.3.4",
     "firebase": "^9.6",
+    "ngx-webstorage": "^9.0.0",
     "rxjs": "~7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "^0.11.5"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Auth, onAuthStateChanged, User } from '@angular/fire/auth';
+import { Auth, onAuthStateChanged, signOut, User } from '@angular/fire/auth';
 import { Router } from '@angular/router';
 
 @Component({
@@ -16,8 +16,8 @@ export class AppComponent {
     });
   }
 
-  logout() {
-    this.auth.signOut();
+  async logout() {
+    await signOut(this.auth);
     this.router.navigateByUrl('/login');
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/fire/firestore';
 import { connectAuthEmulator, getAuth, provideAuth } from '@angular/fire/auth';
 import { MatButtonModule } from '@angular/material/button';
+import { NgxWebstorageModule } from 'ngx-webstorage';
 
 @NgModule({
   declarations: [AppComponent],
@@ -56,6 +57,11 @@ import { MatButtonModule } from '@angular/material/button';
     MatListModule,
     MatSidenavModule,
     MatToolbarModule,
+    NgxWebstorageModule.forRoot({
+      prefix: 'fukagawa-coffee',
+      separator: '.',
+      caseSensitive: false,
+    }),
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/login/login-by-email/login-by-email.component.html
+++ b/src/app/login/login-by-email/login-by-email.component.html
@@ -24,7 +24,7 @@
   </mat-form-field>
 
   <div class="actions">
-    <button color="primary" mat-button (click)="register = true">
+    <button color="primary" mat-button (click)="register = true" type="button">
       新規登録
     </button>
     <button color="primary" mat-flat-button type="submit">
@@ -60,7 +60,7 @@
   </mat-form-field>
 
   <div class="actions">
-    <button mat-button color="primary" (click)="register = false">
+    <button mat-button color="primary" (click)="register = false" type="button">
       キャンセル
     </button>
     <button color="primary" mat-flat-button type="submit">

--- a/src/app/login/login-by-email/login-by-email.component.html
+++ b/src/app/login/login-by-email/login-by-email.component.html
@@ -63,6 +63,9 @@
     <button mat-button color="primary" (click)="register = false">
       キャンセル
     </button>
-    <button color="primary" mat-flat-button type="submit">新規登録</button>
+    <button color="primary" mat-flat-button type="submit">
+      <mat-icon>how_to_reg</mat-icon>
+      新規登録
+    </button>
   </div>
 </form>

--- a/src/app/login/login-by-email/login-by-email.component.html
+++ b/src/app/login/login-by-email/login-by-email.component.html
@@ -1,0 +1,68 @@
+<form *ngIf="!register" [formGroup]="credentials" (ngSubmit)="login()">
+  <mat-form-field>
+    <mat-label> メールアドレス </mat-label>
+    <input
+      type="email"
+      name="email"
+      autocomplete="email"
+      matInput
+      required
+      formControlName="email"
+    />
+  </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>パスワード</mat-label>
+    <input
+      type="password"
+      name="password"
+      autocomplete="current-password"
+      matInput
+      required
+      formControlName="password"
+    />
+  </mat-form-field>
+
+  <div class="actions">
+    <button color="primary" mat-button (click)="register = true">
+      新規登録
+    </button>
+    <button color="primary" mat-flat-button type="submit">
+      <mat-icon>login</mat-icon>
+      ログイン
+    </button>
+  </div>
+</form>
+
+<form *ngIf="register" [formGroup]="credentials" (ngSubmit)="createAccount()">
+  <mat-form-field>
+    <mat-label> メールアドレス </mat-label>
+    <input
+      type="email"
+      name="email"
+      autocomplete="email"
+      matInput
+      required
+      formControlName="email"
+    />
+  </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>パスワード</mat-label>
+    <input
+      type="password"
+      name="password"
+      autocomplete="new-password"
+      matInput
+      required
+      formControlName="password"
+    />
+  </mat-form-field>
+
+  <div class="actions">
+    <button mat-button color="primary" (click)="register = false">
+      キャンセル
+    </button>
+    <button color="primary" mat-flat-button type="submit">新規登録</button>
+  </div>
+</form>

--- a/src/app/login/login-by-email/login-by-email.component.scss
+++ b/src/app/login/login-by-email/login-by-email.component.scss
@@ -1,0 +1,16 @@
+mat-form-field {
+  width: 100%;
+
+  &:first-of-type {
+    margin-top: 1rem;
+  }
+}
+
+.actions {
+  display: flex;
+  column-gap: 1rem;
+
+  button {
+    flex-grow: 1;
+  }
+}

--- a/src/app/login/login-by-email/login-by-email.component.spec.ts
+++ b/src/app/login/login-by-email/login-by-email.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginByEmailComponent } from './login-by-email.component';
+
+describe('LoginByEmailComponent', () => {
+  let component: LoginByEmailComponent;
+  let fixture: ComponentFixture<LoginByEmailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoginByEmailComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginByEmailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/login/login-by-email/login-by-email.component.ts
+++ b/src/app/login/login-by-email/login-by-email.component.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import {
+  Auth,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+} from '@angular/fire/auth';
+import { FormBuilder } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login-by-email',
+  templateUrl: './login-by-email.component.html',
+  styleUrls: ['./login-by-email.component.scss'],
+})
+export class LoginByEmailComponent {
+  register = false;
+  credentials;
+
+  constructor(
+    private auth: Auth,
+    private fb: FormBuilder,
+    private snack: MatSnackBar,
+    private router: Router
+  ) {
+    this.credentials = this.fb.group({
+      email: [''],
+      password: [''],
+    });
+  }
+
+  async createAccount() {
+    const { email, password } = this.credentials.value;
+    try {
+      await createUserWithEmailAndPassword(this.auth, email, password);
+      this.router.navigateByUrl('/');
+    } catch (e) {
+      console.error(e);
+      this.snack.open('新規登録ができませんでした');
+    }
+  }
+
+  async login() {
+    const { email, password } = this.credentials.value;
+    try {
+      await signInWithEmailAndPassword(this.auth, email, password);
+      this.router.navigateByUrl('/');
+    } catch (e) {
+      console.error(e);
+      this.snack.open('ログインに失敗しました');
+    }
+  }
+}

--- a/src/app/login/login-by-phone/login-by-phone.component.html
+++ b/src/app/login/login-by-phone/login-by-phone.component.html
@@ -1,0 +1,53 @@
+<ng-container *ngIf="!codeReady">
+  <mat-form-field>
+    <mat-label> 電話番号 </mat-label>
+    <input
+      type="tel"
+      matInput
+      [(ngModel)]="phoneNumber"
+      name="phone"
+      required
+    />
+  </mat-form-field>
+
+  <div class="actions">
+    <button
+      mat-flat-button
+      color="primary"
+      id="send-confirmation"
+      (click)="sendConfirmation()"
+      [disabled]="isSent"
+    >
+      <mat-icon>textsms</mat-icon>
+      確認コードを送信
+    </button>
+  </div>
+</ng-container>
+
+<ng-container *ngIf="codeReady">
+  <mat-form-field>
+    <mat-label> 確認コード </mat-label>
+    <input
+      type="number"
+      matInput
+      [(ngModel)]="confirmationCode"
+      name="confcode"
+      required
+    />
+  </mat-form-field>
+
+  <div class="actions">
+    <button mat-stroked-button color="primary" (click)="codeReady = false">
+      キャンセル
+    </button>
+    <button
+      mat-flat-button
+      color="primary"
+      (click)="confirmCode()"
+      [disabled]="isSent"
+    >
+      <mat-icon>login</mat-icon>
+      ログイン
+    </button>
+  </div>
+</ng-container>

--- a/src/app/login/login-by-phone/login-by-phone.component.scss
+++ b/src/app/login/login-by-phone/login-by-phone.component.scss
@@ -1,0 +1,13 @@
+mat-form-field {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.actions {
+  display: flex;
+  column-gap: 1rem;
+
+  button {
+    flex-grow: 1;
+  }
+}

--- a/src/app/login/login-by-phone/login-by-phone.component.spec.ts
+++ b/src/app/login/login-by-phone/login-by-phone.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginByPhoneComponent } from './login-by-phone.component';
+
+describe('LoginByPhoneComponent', () => {
+  let component: LoginByPhoneComponent;
+  let fixture: ComponentFixture<LoginByPhoneComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoginByPhoneComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginByPhoneComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/login/login-by-phone/login-by-phone.component.ts
+++ b/src/app/login/login-by-phone/login-by-phone.component.ts
@@ -1,0 +1,77 @@
+import { Component } from '@angular/core';
+import {
+  Auth,
+  ConfirmationResult,
+  RecaptchaVerifier,
+  signInWithPhoneNumber,
+} from '@angular/fire/auth';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-login-by-phone',
+  templateUrl: './login-by-phone.component.html',
+  styleUrls: ['./login-by-phone.component.scss'],
+})
+export class LoginByPhoneComponent {
+  phoneNumber = '';
+  confirmationCode = '';
+  isSent = false;
+  codeReady = false;
+
+  private authResult?: ConfirmationResult;
+
+  constructor(private auth: Auth, private sb: MatSnackBar) {}
+
+  sendConfirmation() {
+    const verifier = new RecaptchaVerifier(
+      'send-confirmation',
+      {
+        size: 'invisible',
+      },
+      this.auth
+    );
+
+    this.isSent = true;
+    const phoneNumber = this.phoneNumber.startsWith('+')
+      ? this.phoneNumber
+      : '+81' + this.phoneNumber;
+
+    signInWithPhoneNumber(this.auth, phoneNumber, verifier).then(
+      (result) => {
+        this.codeReady = true;
+
+        this.sb
+          .open('確認コードを送信しました。')
+          .afterDismissed()
+          .subscribe(() => {
+            this.isSent = false;
+          });
+
+        this.authResult = result;
+      },
+      () => {
+        this.isSent = false;
+        verifier.clear();
+        this.sb.open(
+          '確認コードを送信できませんでした。電話番号を確認してください。'
+        );
+      }
+    );
+  }
+
+  confirmCode() {
+    if (this.authResult) {
+      this.isSent = true;
+      this.authResult.confirm(this.confirmationCode.toString()).then(
+        () => {
+          location.reload();
+        },
+        () => {
+          this.isSent = false;
+          this.codeReady = false;
+          this.sb.open('ログインに失敗しました。');
+        }
+      );
+    }
+  }
+}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -2,7 +2,10 @@
   <mat-card-title>ログイン</mat-card-title>
 
   <mat-card-content>
-    <mat-tab-group>
+    <mat-tab-group
+      #tabGroup
+      (selectedIndexChange)="setLastLoginMethodIndex($event)"
+    >
       <mat-tab label="電話番号">
         <app-login-by-phone></app-login-by-phone>
       </mat-tab>

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,51 +1,14 @@
-<mat-card *ngIf="!codeReady">
-  <mat-card-title> ログイン </mat-card-title>
+<mat-card>
+  <mat-card-title>ログイン</mat-card-title>
 
   <mat-card-content>
-    <mat-form-field appearance="fill">
-      <mat-label> 電話番号 </mat-label>
-      <input type="tel" matInput [(ngModel)]="phoneNumber" name="phone" />
-    </mat-form-field>
+    <mat-tab-group>
+      <mat-tab label="電話番号">
+        <app-login-by-phone></app-login-by-phone>
+      </mat-tab>
+      <mat-tab label="メールアドレス">
+        <app-login-by-email></app-login-by-email>
+      </mat-tab>
+    </mat-tab-group>
   </mat-card-content>
-
-  <mat-card-actions>
-    <button
-      mat-raised-button
-      color="primary"
-      id="send-confirmation"
-      (click)="sendConfirmation()"
-      [disabled]="isSent"
-    >
-      <mat-icon>textsms</mat-icon>
-      確認コードを送信
-    </button>
-  </mat-card-actions>
-</mat-card>
-
-<mat-card *ngIf="codeReady">
-  <mat-card-title> 確認コードを入力 </mat-card-title>
-
-  <mat-card-content>
-    <mat-form-field appearance="fill">
-      <mat-label> 確認コード </mat-label>
-      <input
-        type="number"
-        matInput
-        [(ngModel)]="confirmationCode"
-        name="confcode"
-      />
-    </mat-form-field>
-  </mat-card-content>
-
-  <mat-card-actions>
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="confirmCode()"
-      [disabled]="isSent"
-    >
-      <mat-icon>login</mat-icon>
-      ログイン
-    </button>
-  </mat-card-actions>
 </mat-card>

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -1,3 +1,3 @@
 mat-card {
-    margin: 1em;
+  margin: 2rem 1rem;
 }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,8 +1,28 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { MatTabGroup } from '@angular/material/tabs';
+import { LocalStorageService } from 'ngx-webstorage';
 
 @Component({
   selector: 'app-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
 })
-export class LoginComponent {}
+export class LoginComponent implements AfterViewInit {
+  private lastLoginMethodIndexKey = 'login.lastLoginMethodIndex';
+  @ViewChild('tabGroup') tabGroup?: MatTabGroup;
+
+  constructor(private storage: LocalStorageService) {}
+
+  ngAfterViewInit(): void {
+    if (!this.tabGroup) return;
+
+    const index = Number(
+      this.storage.retrieve(this.lastLoginMethodIndexKey) ?? 0
+    );
+    this.tabGroup.selectedIndex = index;
+  }
+
+  setLastLoginMethodIndex(index: number) {
+    this.storage.store(this.lastLoginMethodIndexKey, index);
+  }
+}

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,85 +1,8 @@
 import { Component } from '@angular/core';
-import {
-  Auth,
-  ConfirmationResult,
-  RecaptchaVerifier,
-  signInWithPhoneNumber,
-} from '@angular/fire/auth';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
 })
-export class LoginComponent {
-  phoneNumber = '';
-  confirmationCode = '';
-  isSent = false;
-  codeReady = false;
-
-  private authResult?: ConfirmationResult;
-
-  constructor(private auth: Auth, private sb: MatSnackBar) {}
-
-  sendConfirmation() {
-    const verifier = new RecaptchaVerifier(
-      'send-confirmation',
-      {
-        size: 'invisible',
-      },
-      this.auth
-    );
-
-    this.isSent = true;
-    const phoneNumber = this.phoneNumber.startsWith('+')
-      ? this.phoneNumber
-      : '+81' + this.phoneNumber;
-
-    signInWithPhoneNumber(this.auth, phoneNumber, verifier).then(
-      (result) => {
-        this.codeReady = true;
-
-        this.sb
-          .open('確認コードを送信しました。', undefined, {
-            duration: 2000,
-          })
-          .afterDismissed()
-          .subscribe(() => {
-            this.isSent = false;
-          });
-
-        this.authResult = result;
-      },
-      () => {
-        this.isSent = false;
-        verifier.clear();
-        this.sb.open(
-          '確認コードを送信できませんでした。電話番号を確認してください。',
-          undefined,
-          {
-            duration: 2000,
-          }
-        );
-      }
-    );
-  }
-
-  confirmCode() {
-    if (this.authResult) {
-      this.isSent = true;
-      this.authResult.confirm(this.confirmationCode.toString()).then(
-        () => {
-          location.reload();
-        },
-        () => {
-          this.isSent = false;
-          this.codeReady = false;
-          this.sb.open('ログインに失敗しました。', undefined, {
-            duration: 2000,
-          });
-        }
-      );
-    }
-  }
-}
+export class LoginComponent {}

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -1,20 +1,30 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
+import {
+  MatFormFieldModule,
+  MAT_FORM_FIELD_DEFAULT_OPTIONS,
+} from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
+import { LoginByEmailComponent } from './login-by-email/login-by-email.component';
+import { LoginByPhoneComponent } from './login-by-phone/login-by-phone.component';
 import { LoginRoutingModule } from './login-routing.module';
 import { LoginComponent } from './login.component';
 
 @NgModule({
-  declarations: [LoginComponent],
+  declarations: [LoginComponent, LoginByPhoneComponent, LoginByEmailComponent],
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     LoginRoutingModule,
     MatButtonModule,
     MatCardModule,
@@ -22,6 +32,17 @@ import { LoginComponent } from './login.component';
     MatIconModule,
     MatInputModule,
     MatSnackBarModule,
+    MatTabsModule,
+  ],
+  providers: [
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { appearance: 'fill' },
+    },
+    {
+      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
+      useValue: { duration: 2000 },
+    },
   ],
 })
 export class LoginModule {}


### PR DESCRIPTION
fix #55

## 変更内容

- ログイン画面のマークアップを改善
- Eメールログインを実装
  - 新規登録
  - 既存ユーザーログイン
  - パスワードリセット
  -
- 最後に使用したログイン方法を `LocalStorage` に覚えておく

## コメント

ログインの単体テストをするのに便利になるはず